### PR TITLE
enable use capture for keyboard events

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -256,11 +256,8 @@
   }
 
   // cross-browser events
-  function addEvent(object, event, method) {
-    if (object.addEventListener)
-      object.addEventListener(event, method, false);
-    else if(object.attachEvent)
-      object.attachEvent('on'+event, function(){ method(window.event) });
+  function addEvent(element, event, method) {
+    element.addEventListener(event, method, {capture: true});
   };
 
   // set the handlers globally on document


### PR DESCRIPTION
- remove `attachEvent` code (we do not require IE support)
- enable use capture (to facilitate preventing default by returning false)